### PR TITLE
separated terrain1, rocks, and grass into separate objects

### DIFF
--- a/VS2017/Source/Grass.cpp
+++ b/VS2017/Source/Grass.cpp
@@ -15,23 +15,16 @@ Grass::Grass(const Shader& shader, Object& cubeObject) : ComplexModel(shader)
 	glm::vec4 dirtBrown(0.3f, 0.15f, 0.03f, 1.0f);
 	glm::vec4 dimGray(0.412f, 0.412f, 0.412f, 1.0f);
 
-	float initialX = 0;
-	float initialY = 0;
-	float initialZ = 0;
-
-	float height = 1.0;
-	float width = 1.0;
-
-	scale = glm::vec3(width * 0.025f, height * 0.3f, width * 0.01f);
-	translation = glm::vec3(initialX, initialY, initialZ);
+	scale = glm::vec3(0.025f, 0.3f, 0.01f);
+	translation = glm::vec3(0.0f, 0.0f, 0.0f);
 	Model* herb1 = new Model(cubeObject, translation, angle, rotation, scale, limeGreen);
 	addModel(herb1);
 
-	translation = glm::vec3(initialX + 1.0f, initialY, initialZ + 1.0f);
+	translation = glm::vec3(1.0f, 0.0f, 1.0f);
 	Model* herb2 = new Model(cubeObject, translation, angle, rotation, scale, limeGreen);
 	addModel(herb2);
 
-	translation = glm::vec3(initialX + 1.5f, initialY, initialZ + 1.5f);
+	translation = glm::vec3(1.5f, 0.0f, 1.5f);
 	Model* herb3 = new Model(cubeObject, translation, angle, rotation, scale, limeGreen);
 	addModel(herb3);
 

--- a/VS2017/Source/Grass.cpp
+++ b/VS2017/Source/Grass.cpp
@@ -1,0 +1,38 @@
+#include "Grass.h"
+
+Grass::Grass(const Shader& shader, Object& cubeObject) : ComplexModel(shader)
+{
+	shader.Bind();
+
+
+	// 4 cube base with single cube on top
+	glm::vec3 translation(1.0f, 1.0f, 1.0f);
+	glm::vec3 rotation(1.0f, 1.0f, 1.0f);
+	float angle = 0.0f;
+	glm::vec3 scale(0.5f, 0.5f, 0.5f);
+	glm::vec4 limeGreen(0.196f, 0.804f, 0.196f, 1.0f);
+	glm::vec4 yellow(0.8f, 0.7f, 0.0f, 1.0f);
+	glm::vec4 dirtBrown(0.3f, 0.15f, 0.03f, 1.0f);
+	glm::vec4 dimGray(0.412f, 0.412f, 0.412f, 1.0f);
+
+	float initialX = 0;
+	float initialY = 0;
+	float initialZ = 0;
+
+	float height = 1.0;
+	float width = 1.0;
+
+	scale = glm::vec3(width * 0.025f, height * 0.3f, width * 0.01f);
+	translation = glm::vec3(initialX, initialY, initialZ);
+	Model* herb1 = new Model(cubeObject, translation, angle, rotation, scale, limeGreen);
+	addModel(herb1);
+
+	translation = glm::vec3(initialX + 1.0f, initialY, initialZ + 1.0f);
+	Model* herb2 = new Model(cubeObject, translation, angle, rotation, scale, limeGreen);
+	addModel(herb2);
+
+	translation = glm::vec3(initialX + 1.5f, initialY, initialZ + 1.5f);
+	Model* herb3 = new Model(cubeObject, translation, angle, rotation, scale, limeGreen);
+	addModel(herb3);
+
+}

--- a/VS2017/Source/Grass.h
+++ b/VS2017/Source/Grass.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "ComplexModel.h"
+
+class Grass : public ComplexModel {
+public:
+	Grass(const Shader& shader, Object& cubeObject);
+
+private:
+
+};

--- a/VS2017/Source/Rocks.cpp
+++ b/VS2017/Source/Rocks.cpp
@@ -15,25 +15,18 @@ Rocks::Rocks(const Shader& shader, Object& cubeObject) : ComplexModel(shader)
 	glm::vec4 dirtBrown(0.3f, 0.15f, 0.03f, 1.0f);
 	glm::vec4 dimGray(0.412f, 0.412f, 0.412f, 1.0f);
 
-	float initialX = 0;
-	float initialY = 0;
-	float initialZ = 0;
-
-	float height = 1.0;
-	float width = 1.0;
-
-	scale = glm::vec3(width * 0.3f, height * 0.2f, width * 0.3f);
-	translation = glm::vec3(initialX, initialY, initialZ);
+	scale = glm::vec3(0.3f, 0.2f, 0.3f);
+	translation = glm::vec3(0.0f, 0.0f, 0.0f);
 	Model* rock1 = new Model(cubeObject, translation, angle, rotation, scale, dimGray);
 	addModel(rock1);
 
-	scale = glm::vec3(width * 0.2f, height * 0.05f, width * 0.2f);
-	translation = glm::vec3(initialX , initialY + 1.0f, initialZ);
+	scale = glm::vec3(0.2f, 0.05f, 0.2f);
+	translation = glm::vec3(0.0f , 1.0f, 0.0f);
 	Model* rock2 = new Model(cubeObject, translation, angle, rotation, scale, dimGray);
 	addModel(rock2);
 
-	scale = glm::vec3(width * 0.2f, height * 0.1f, width * 0.25f);
-	translation = glm::vec3(initialX + 3.0f, initialY, initialZ -2.0f);
+	scale = glm::vec3(0.2f, 0.1f, 0.25f);
+	translation = glm::vec3(3.0f, 0.0f, -2.0f);
 	Model* rock3 = new Model(cubeObject, translation, angle, rotation, scale, dimGray);
 	addModel(rock3);
 }

--- a/VS2017/Source/Rocks.cpp
+++ b/VS2017/Source/Rocks.cpp
@@ -1,0 +1,39 @@
+#include "Rocks.h"
+
+Rocks::Rocks(const Shader& shader, Object& cubeObject) : ComplexModel(shader)
+{
+	shader.Bind();
+
+
+	// 4 cube base with single cube on top
+	glm::vec3 translation(1.0f, 1.0f, 1.0f);
+	glm::vec3 rotation(1.0f, 1.0f, 1.0f);
+	float angle = 0.0f;
+	glm::vec3 scale(0.5f, 0.5f, 0.5f);
+	glm::vec4 limeGreen(0.196f, 0.804f, 0.196f, 1.0f);
+	glm::vec4 yellow(0.8f, 0.7f, 0.0f, 1.0f);
+	glm::vec4 dirtBrown(0.3f, 0.15f, 0.03f, 1.0f);
+	glm::vec4 dimGray(0.412f, 0.412f, 0.412f, 1.0f);
+
+	float initialX = 0;
+	float initialY = 0;
+	float initialZ = 0;
+
+	float height = 1.0;
+	float width = 1.0;
+
+	scale = glm::vec3(width * 0.3f, height * 0.2f, width * 0.3f);
+	translation = glm::vec3(initialX, initialY, initialZ);
+	Model* rock1 = new Model(cubeObject, translation, angle, rotation, scale, dimGray);
+	addModel(rock1);
+
+	scale = glm::vec3(width * 0.2f, height * 0.05f, width * 0.2f);
+	translation = glm::vec3(initialX , initialY + 1.0f, initialZ);
+	Model* rock2 = new Model(cubeObject, translation, angle, rotation, scale, dimGray);
+	addModel(rock2);
+
+	scale = glm::vec3(width * 0.2f, height * 0.1f, width * 0.25f);
+	translation = glm::vec3(initialX + 3.0f, initialY, initialZ -2.0f);
+	Model* rock3 = new Model(cubeObject, translation, angle, rotation, scale, dimGray);
+	addModel(rock3);
+}

--- a/VS2017/Source/Rocks.h
+++ b/VS2017/Source/Rocks.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "ComplexModel.h"
+
+class Rocks : public ComplexModel {
+public:
+	Rocks(const Shader& shader, Object& cubeObject);
+
+private:
+
+};

--- a/VS2017/Source/Terrain1.cpp
+++ b/VS2017/Source/Terrain1.cpp
@@ -32,43 +32,4 @@ Terrain1::Terrain1(const Shader& shader, Object& cubeObject) : ComplexModel(shad
 	Model* grass = new Model(cubeObject, translation, angle, rotation, scale, limeGreen);
 	addModel(grass);
 
-	scale = glm::vec3(width * 0.025f, height * 0.3f, width * 0.01f);
-	translation = glm::vec3(initialX+13.0f, initialY+1.5, initialZ + 13.0f);
-	Model* herb1 = new Model(cubeObject, translation, angle, rotation, scale, limeGreen);
-	addModel(herb1);
-
-	translation = glm::vec3(initialX + 14.0f, initialY + 1.5, initialZ + 14.0f);
-	Model* herb2 = new Model(cubeObject, translation, angle, rotation, scale, limeGreen);
-	addModel(herb2);
-
-	translation = glm::vec3(initialX + 13.5f, initialY + 1.5, initialZ + 13.5f);
-	Model* herb3 = new Model(cubeObject, translation, angle, rotation, scale, limeGreen);
-	addModel(herb3);
-
-	translation = glm::vec3(initialX - 13.0f, initialY + 1.5, initialZ - 13.0f);
-	Model* herb4 = new Model(cubeObject, translation, angle, rotation, scale, limeGreen);
-	addModel(herb4);
-
-	translation = glm::vec3(initialX - 14.0f, initialY + 1.5, initialZ - 14.0f);
-	Model* herb5 = new Model(cubeObject, translation, angle, rotation, scale, limeGreen);
-	addModel(herb5);
-
-	translation = glm::vec3(initialX - 13.5f, initialY + 1.5, initialZ - 14.0f);
-	Model* herb6 = new Model(cubeObject, translation, angle, rotation, scale, limeGreen);
-	addModel(herb6);
-
-	scale = glm::vec3(width * 0.3f, height * 0.2f, width * 0.3f);
-	translation = glm::vec3(initialX - 8.0f, initialY + 1.5, initialZ + 10.0f);
-	Model* rock1= new Model(cubeObject, translation, angle, rotation, scale, dimGray);
-	addModel(rock1);
-
-	scale = glm::vec3(width * 0.2f, height * 0.05f, width * 0.2f);
-	translation = glm::vec3(initialX - 8.0f, initialY + 2.5f, initialZ + 10.0f);
-	Model* rock2 = new Model(cubeObject, translation, angle, rotation, scale, dimGray);
-	addModel(rock2);
-
-	scale = glm::vec3(width * 0.2f, height * 0.1f, width * 0.25f);
-	translation = glm::vec3(initialX - 5.0f, initialY + 1.5f, initialZ + 8.0f);
-	Model* rock3 = new Model(cubeObject, translation, angle, rotation, scale, dimGray);
-	addModel(rock3);
 }

--- a/VS2017/Source/Terrain1.cpp
+++ b/VS2017/Source/Terrain1.cpp
@@ -15,20 +15,13 @@ Terrain1::Terrain1(const Shader& shader, Object& cubeObject) : ComplexModel(shad
 	glm::vec4 dirtBrown(0.3f, 0.15f, 0.03f, 1.0f);
 	glm::vec4 dimGray(0.412f, 0.412f, 0.412f, 1.0f);
 
-	float initialX = 0;
-	float initialY = 0;
-	float initialZ = 0;
-
-	float height = 1.0;
-	float width = 1.0;
-
-	scale = glm::vec3(width * 5.0f, height * 0.2f, width * 5.0f);
-	translation = glm::vec3(initialX, initialY, initialZ);
+	scale = glm::vec3(5.0f, 0.2f, 5.0f);
+	translation = glm::vec3(0.0f, 0.0f, 0.0f);
 	Model* dirt = new Model(cubeObject, translation, angle, rotation, scale, dirtBrown);
 	addModel(dirt);
 
-	scale = glm::vec3(width * 5.0f, height * 0.05f, width * 5.0f);
-	translation = glm::vec3(initialX, initialY+1.25, initialZ);
+	scale = glm::vec3(5.0f, 0.05f, 5.0f);
+	translation = glm::vec3(0.0f, 1.25f, 0.0f);
 	Model* grass = new Model(cubeObject, translation, angle, rotation, scale, limeGreen);
 	addModel(grass);
 

--- a/VS2017/Source/Tree1.cpp
+++ b/VS2017/Source/Tree1.cpp
@@ -14,61 +14,54 @@ Tree1::Tree1(const Shader& shader, Object& cubeObject) : ComplexModel(shader)
 	glm::vec4 yellow(0.8f, 0.7f, 0.0f, 1.0f);
 	glm::vec4 brown(0.545f, 0.271f, 0.075f, 1.0f);
 	
-	float initialX = 0;
-	float initialY = 0;
-	float initialZ = 0;
-
-	float height = 1.0;
-	float width = 1.0;
-
-	scale = glm::vec3(width * 0.5f, height * 3.0f, width* 0.5f);
-	translation = glm::vec3(initialX, initialY, initialZ);
+	scale = glm::vec3(0.5f, 3.0f, 0.5f);
+	translation = glm::vec3(0.0f, 0.0f, 0.0f);
 	Model* trunk = new Model(cubeObject, translation, angle, rotation, scale, brown);
 	addModel(trunk);
 
-	scale = glm::vec3(width * 0.3f, height * 3.0f, width * 0.12f);
-	translation = glm::vec3(initialX, initialY, initialZ);
+	scale = glm::vec3(0.3f, 3.0f, 0.12f);
+	translation = glm::vec3(0.0f, 0.0f, 0.0f);
 	Model* trunkSide1 = new Model(cubeObject, translation, angle, rotation, scale, brown);
 	addModel(trunkSide1);
 
-	translation = glm::vec3(initialX, initialY, initialZ - 2.5f);
+	translation = glm::vec3(0.0f, 0.0f, -2.5f);
 	Model* trunkSide2 = new Model(cubeObject, translation, angle, rotation, scale, brown);
 	addModel(trunkSide2);
 
-	scale = glm::vec3(width * 0.12f, height * 3.0f, width * 0.3f);
-	translation = glm::vec3(initialX - 2.5f, initialY, initialZ);
+	scale = glm::vec3(0.12f, 3.0f, 0.3f);
+	translation = glm::vec3(-2.5f, 0.0f, 0.0f);
 	Model* trunkSide3 = new Model(cubeObject, translation, angle, rotation, scale, brown);
 	addModel(trunkSide3);
 
-	translation = glm::vec3(initialX + 2.5f, initialY, initialZ);
+	translation = glm::vec3(2.5f, 0.0f, 0.0f);
 	Model* trunkSide4 = new Model(cubeObject, translation, angle, rotation, scale, brown);
 	addModel(trunkSide4);
 
-	scale = glm::vec3(width * 1.5f, height* 1.0f, width * 1.5f);
-	translation = glm::vec3(initialX, initialY + 16.0f, initialZ);
+	scale = glm::vec3(1.5f, 1.0f, 1.5f);
+	translation = glm::vec3(0.0f, 16.0f, 0.0f);
 	Model* leaves = new Model(cubeObject, translation, angle, rotation, scale, green);
 	addModel(leaves);
 
-	scale = glm::vec3(width * 1.2f, height * 0.3f, width * 1.2f);
-	translation = glm::vec3(initialX, initialY + 22.0f, initialZ);
+	scale = glm::vec3(1.2f, 0.3f, 1.2f);
+	translation = glm::vec3(0.0f, 22.0f, 0.0f);
 	Model* leavesTop = new Model(cubeObject, translation, angle, rotation, scale, green);
 	addModel(leavesTop);
 
-	scale = glm::vec3(width * 1.3f, height * 0.8f, width * 0.3f);
-	translation = glm::vec3(initialX, initialY + 16.0f, initialZ + 8.0f);
+	scale = glm::vec3(1.3f, 0.8f, 0.3f);
+	translation = glm::vec3(0.0f, 16.0f, 8.0f);
 	Model* leavesSide1 = new Model(cubeObject, translation, angle, rotation, scale, green);
 	addModel(leavesSide1);
 
-	translation = glm::vec3(initialX, initialY + 16.0f, initialZ -8.0f);
+	translation = glm::vec3(0.0f, 16.0f, -8.0f);
 	Model* leavesSide2 = new Model(cubeObject, translation, angle, rotation, scale, green);
 	addModel(leavesSide2);
 
-	scale = glm::vec3(width * 0.3f, height * 0.8f, width * 1.3f);
-	translation = glm::vec3(initialX + 8.0f, initialY + 16.0f, initialZ);
+	scale = glm::vec3(0.3f, 0.8f, 1.3f);
+	translation = glm::vec3(8.0f, 16.0f, 0.0f);
 	Model* leavesSide3 = new Model(cubeObject, translation, angle, rotation, scale, green);
 	addModel(leavesSide3);
 
-	translation = glm::vec3(initialX - 8.0f, initialY + 16.0f, initialZ);
+	translation = glm::vec3(-8.0f, 16.0f, 0.0f);
 	Model* leavesSide4 = new Model(cubeObject, translation, angle, rotation, scale, green);
 	addModel(leavesSide4);
 }

--- a/VS2017/Source/application.cpp
+++ b/VS2017/Source/application.cpp
@@ -33,6 +33,8 @@
 
 #include "tests/TestTree1.h"
 #include "tests/TestTerrain1.h"
+#include "tests/TestGrass.h"
+#include "tests/TestRocks.h"
 
 int main(void)
 {
@@ -91,6 +93,8 @@ int main(void)
         testMenu->RegisterTest<test::TestComplexModel>("ComplexModel");
         testMenu->RegisterTest<test::TestTree1>("TestTree1");
         testMenu->RegisterTest<test::TestTerrain1>("TestTerrain1");
+        testMenu->RegisterTest<test::TestGrass>("TestGrass");
+        testMenu->RegisterTest<test::TestRocks>("TestRocks");
         
         /* Loop until the user closes the window */
         while (!glfwWindowShouldClose(window))

--- a/VS2017/Source/tests/TestGrass.cpp
+++ b/VS2017/Source/tests/TestGrass.cpp
@@ -38,18 +38,7 @@ namespace test {
 		m_complexModel->setRotation(45.0f, glm::vec3(0.0f, 1.0f, 0.0f));
 		m_complexModel->setScale(glm::vec3(0.5f, 0.5f, 0.5f));
 		m_complexModel->computeModelMatrix();
-		/*
-		Model* bottomCube = new Model(m_CubeObject);
-		Model* topTranslatedCube = new Model(m_CubeObject);
-		topTranslatedCube->setTranslation(glm::vec3(10.0f, 10.0f, 1.0f));
-		topTranslatedCube->setRotation(45.0f, glm::vec3(1.0f, 0.0f, 0.0f));
-		topTranslatedCube->setScale(glm::vec3(1.25f, 1.25f, 1.25f));
-		topTranslatedCube->computeModelMatrix();
-
-		m_complexModel->addModel(bottomCube);
-		m_complexModel->addModel(topTranslatedCube);
-
-		*/
+		
 		m_Grass = new Grass(m_Shader, m_CubeObject);
 	}
 

--- a/VS2017/Source/tests/TestGrass.cpp
+++ b/VS2017/Source/tests/TestGrass.cpp
@@ -1,0 +1,106 @@
+#pragma once
+
+#include "IndexBuffer.h"
+#include "VertexArray.h"
+#include "TestGrass.h"
+
+namespace test {
+
+	TestGrass::TestGrass()
+		: m_CubeObject("res/models/cube.obj"), m_Shader("res/shaders/basic_light.shader"),
+		m_BaseTranslation(-10.0f, 0.0f, 0.0f),
+		m_BaseRotation(1.0f, 1.0f, 1.0f),
+		m_BaseScale(0.5f, 0.5f, 0.5f),
+		m_LightPosition(0.0f, 10.0f, 40.0f), m_CameraPosition(0.0f, 10.0f, 60.0f),
+		m_Cube(m_CubeObject), m_BaseAngle(1.0f)
+	{
+
+		// Camera parameters for view transform
+		glm::vec3 cameraLookAt(0.0f, -0.1f, -1.0f);
+		glm::vec3 cameraUp(0.0f, 1.0f, 0.0f);
+
+		// Set projection matrix for shader, this won't change
+		m_Proj = glm::perspective(70.0f,            // field of view in degrees
+			1.0f,  // aspect ratio
+			0.01f, 100.0f);   // near and far (near > 0)
+
+		// Set initial view matrix
+		m_View = lookAt(m_CameraPosition,  // eye
+			m_CameraPosition + cameraLookAt,  // center
+			cameraUp); // up
+
+		GLCall(glEnable(GL_CULL_FACE));
+		glEnable(GL_DEPTH_TEST);
+
+		m_Shader.Bind();
+
+		m_complexModel = new ComplexModel(m_Shader);
+		m_complexModel->setRotation(45.0f, glm::vec3(0.0f, 1.0f, 0.0f));
+		m_complexModel->setScale(glm::vec3(0.5f, 0.5f, 0.5f));
+		m_complexModel->computeModelMatrix();
+		/*
+		Model* bottomCube = new Model(m_CubeObject);
+		Model* topTranslatedCube = new Model(m_CubeObject);
+		topTranslatedCube->setTranslation(glm::vec3(10.0f, 10.0f, 1.0f));
+		topTranslatedCube->setRotation(45.0f, glm::vec3(1.0f, 0.0f, 0.0f));
+		topTranslatedCube->setScale(glm::vec3(1.25f, 1.25f, 1.25f));
+		topTranslatedCube->computeModelMatrix();
+
+		m_complexModel->addModel(bottomCube);
+		m_complexModel->addModel(topTranslatedCube);
+
+		*/
+		m_Grass = new Grass(m_Shader, m_CubeObject);
+	}
+
+	TestGrass::~TestGrass()
+	{
+	}
+
+	void TestGrass::OnUpdate(float deltaTime)
+	{
+	}
+
+	void TestGrass::OnRender()
+	{
+		GLCall(glClearColor(0.8f, 0.3f, 0.8f, 1.0f));
+		GLCall(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
+		Renderer renderer;
+
+		glm::vec3 cameraLookAt(0.0f, -0.1f, -1.0f);
+		glm::vec3 cameraUp(0.0f, 1.0f, 0.0f);
+		// Set initial view matrix
+		m_View = lookAt(m_CameraPosition,  // eye
+			m_CameraPosition + cameraLookAt,  // center
+			cameraUp); // up
+
+
+		m_Shader.Bind();
+		m_Shader.SetUniformMat4f("u_Projection", m_Proj);
+		m_Shader.SetUniformMat4f("u_View", m_View);
+		m_Shader.SetUniform4f("u_Color", 1.0f, 1.0f, 1.0f, 1.0f);
+		m_Shader.SetUniform3fv("u_LightPos", m_LightPosition);
+		m_Shader.SetUniform3fv("u_ViewPos", m_CameraPosition);
+
+		// m_complexModel->setTransforms(m_BaseTranslation, m_BaseAngle, m_BaseRotation, m_BaseScale);
+
+		// m_complexModel->draw();
+
+		m_Grass->draw();
+	}
+
+	void TestGrass::OnImGuiRender()
+	{
+		ImGui::SliderFloat3("Base Translation", &m_BaseTranslation.x, -50.0f, 50.0f);
+		ImGui::SliderFloat("Base Angle", &m_BaseAngle, 0.0f, 360.0f);
+		if (ImGui::Button("Reset Angle")) {
+			m_BaseAngle = 0.0f;
+			m_BaseRotation = glm::vec3(0.0f, 0.0f, 0.0f);
+		}
+		ImGui::SliderFloat3("Base Rotation", &m_BaseRotation.x, -1.0f, 1.0f);
+		ImGui::SliderFloat3("Base Scale", &m_BaseScale.x, 0.0f, 2.0f);
+		ImGui::SliderFloat3("Camera", &m_CameraPosition.x, -50.0f, 50.0f);
+		ImGui::SliderFloat3("Light", &m_LightPosition.x, -50.0f, 50.0f);
+		ImGui::Text("Application average %.3f ms/frame (%.1f FPS)", 1000.0f / ImGui::GetIO().Framerate, ImGui::GetIO().Framerate);
+	}
+}

--- a/VS2017/Source/tests/TestGrass.h
+++ b/VS2017/Source/tests/TestGrass.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "Test.h"
+
+#include "glm/glm.hpp"
+#include "glm/gtc/matrix_transform.hpp"
+#include <memory>
+#include "Object.h"
+#include "Model.h"
+#include "Grass.h"
+
+namespace test {
+
+	class TestGrass : public Test
+	{
+	public:
+		TestGrass();
+		~TestGrass();
+
+		void OnUpdate(float deltaTime) override;
+		void OnRender() override;
+		void OnImGuiRender() override;
+
+	private:
+		Object m_CubeObject;
+		ComplexModel* m_complexModel, * m_Grass;
+		glm::mat4 m_Proj, m_View;
+		float m_BaseAngle;
+		glm::vec3 m_BaseTranslation, m_BaseRotation, m_BaseScale, m_LightPosition, m_CameraPosition;
+		Model m_Cube;
+		Shader m_Shader;
+	};
+}

--- a/VS2017/Source/tests/TestRocks.cpp
+++ b/VS2017/Source/tests/TestRocks.cpp
@@ -38,18 +38,7 @@ namespace test {
 		m_complexModel->setRotation(45.0f, glm::vec3(0.0f, 1.0f, 0.0f));
 		m_complexModel->setScale(glm::vec3(0.5f, 0.5f, 0.5f));
 		m_complexModel->computeModelMatrix();
-		/*
-		Model* bottomCube = new Model(m_CubeObject);
-		Model* topTranslatedCube = new Model(m_CubeObject);
-		topTranslatedCube->setTranslation(glm::vec3(10.0f, 10.0f, 1.0f));
-		topTranslatedCube->setRotation(45.0f, glm::vec3(1.0f, 0.0f, 0.0f));
-		topTranslatedCube->setScale(glm::vec3(1.25f, 1.25f, 1.25f));
-		topTranslatedCube->computeModelMatrix();
-
-		m_complexModel->addModel(bottomCube);
-		m_complexModel->addModel(topTranslatedCube);
-
-		*/
+		
 		m_Rocks = new Rocks(m_Shader, m_CubeObject);
 	}
 

--- a/VS2017/Source/tests/TestRocks.cpp
+++ b/VS2017/Source/tests/TestRocks.cpp
@@ -1,0 +1,106 @@
+#pragma once
+
+#include "IndexBuffer.h"
+#include "VertexArray.h"
+#include "TestRocks.h"
+
+namespace test {
+
+	TestRocks::TestRocks()
+		: m_CubeObject("res/models/cube.obj"), m_Shader("res/shaders/basic_light.shader"),
+		m_BaseTranslation(-10.0f, 0.0f, 0.0f),
+		m_BaseRotation(1.0f, 1.0f, 1.0f),
+		m_BaseScale(0.5f, 0.5f, 0.5f),
+		m_LightPosition(0.0f, 10.0f, 40.0f), m_CameraPosition(0.0f, 10.0f, 60.0f),
+		m_Cube(m_CubeObject), m_BaseAngle(1.0f)
+	{
+
+		// Camera parameters for view transform
+		glm::vec3 cameraLookAt(0.0f, -0.1f, -1.0f);
+		glm::vec3 cameraUp(0.0f, 1.0f, 0.0f);
+
+		// Set projection matrix for shader, this won't change
+		m_Proj = glm::perspective(70.0f,            // field of view in degrees
+			1.0f,  // aspect ratio
+			0.01f, 100.0f);   // near and far (near > 0)
+
+		// Set initial view matrix
+		m_View = lookAt(m_CameraPosition,  // eye
+			m_CameraPosition + cameraLookAt,  // center
+			cameraUp); // up
+
+		GLCall(glEnable(GL_CULL_FACE));
+		glEnable(GL_DEPTH_TEST);
+
+		m_Shader.Bind();
+
+		m_complexModel = new ComplexModel(m_Shader);
+		m_complexModel->setRotation(45.0f, glm::vec3(0.0f, 1.0f, 0.0f));
+		m_complexModel->setScale(glm::vec3(0.5f, 0.5f, 0.5f));
+		m_complexModel->computeModelMatrix();
+		/*
+		Model* bottomCube = new Model(m_CubeObject);
+		Model* topTranslatedCube = new Model(m_CubeObject);
+		topTranslatedCube->setTranslation(glm::vec3(10.0f, 10.0f, 1.0f));
+		topTranslatedCube->setRotation(45.0f, glm::vec3(1.0f, 0.0f, 0.0f));
+		topTranslatedCube->setScale(glm::vec3(1.25f, 1.25f, 1.25f));
+		topTranslatedCube->computeModelMatrix();
+
+		m_complexModel->addModel(bottomCube);
+		m_complexModel->addModel(topTranslatedCube);
+
+		*/
+		m_Rocks = new Rocks(m_Shader, m_CubeObject);
+	}
+
+	TestRocks::~TestRocks()
+	{
+	}
+
+	void TestRocks::OnUpdate(float deltaTime)
+	{
+	}
+
+	void TestRocks::OnRender()
+	{
+		GLCall(glClearColor(0.8f, 0.3f, 0.8f, 1.0f));
+		GLCall(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
+		Renderer renderer;
+
+		glm::vec3 cameraLookAt(0.0f, -0.1f, -1.0f);
+		glm::vec3 cameraUp(0.0f, 1.0f, 0.0f);
+		// Set initial view matrix
+		m_View = lookAt(m_CameraPosition,  // eye
+			m_CameraPosition + cameraLookAt,  // center
+			cameraUp); // up
+
+
+		m_Shader.Bind();
+		m_Shader.SetUniformMat4f("u_Projection", m_Proj);
+		m_Shader.SetUniformMat4f("u_View", m_View);
+		m_Shader.SetUniform4f("u_Color", 1.0f, 1.0f, 1.0f, 1.0f);
+		m_Shader.SetUniform3fv("u_LightPos", m_LightPosition);
+		m_Shader.SetUniform3fv("u_ViewPos", m_CameraPosition);
+
+		// m_complexModel->setTransforms(m_BaseTranslation, m_BaseAngle, m_BaseRotation, m_BaseScale);
+
+		// m_complexModel->draw();
+
+		m_Rocks->draw();
+	}
+
+	void TestRocks::OnImGuiRender()
+	{
+		ImGui::SliderFloat3("Base Translation", &m_BaseTranslation.x, -50.0f, 50.0f);
+		ImGui::SliderFloat("Base Angle", &m_BaseAngle, 0.0f, 360.0f);
+		if (ImGui::Button("Reset Angle")) {
+			m_BaseAngle = 0.0f;
+			m_BaseRotation = glm::vec3(0.0f, 0.0f, 0.0f);
+		}
+		ImGui::SliderFloat3("Base Rotation", &m_BaseRotation.x, -1.0f, 1.0f);
+		ImGui::SliderFloat3("Base Scale", &m_BaseScale.x, 0.0f, 2.0f);
+		ImGui::SliderFloat3("Camera", &m_CameraPosition.x, -50.0f, 50.0f);
+		ImGui::SliderFloat3("Light", &m_LightPosition.x, -50.0f, 50.0f);
+		ImGui::Text("Application average %.3f ms/frame (%.1f FPS)", 1000.0f / ImGui::GetIO().Framerate, ImGui::GetIO().Framerate);
+	}
+}

--- a/VS2017/Source/tests/TestRocks.h
+++ b/VS2017/Source/tests/TestRocks.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "Test.h"
+
+#include "glm/glm.hpp"
+#include "glm/gtc/matrix_transform.hpp"
+#include <memory>
+#include "Object.h"
+#include "Model.h"
+#include "Rocks.h"
+
+namespace test {
+
+	class TestRocks : public Test
+	{
+	public:
+		TestRocks();
+		~TestRocks();
+
+		void OnUpdate(float deltaTime) override;
+		void OnRender() override;
+		void OnImGuiRender() override;
+
+	private:
+		Object m_CubeObject;
+		ComplexModel* m_complexModel, * m_Rocks;
+		glm::mat4 m_Proj, m_View;
+		float m_BaseAngle;
+		glm::vec3 m_BaseTranslation, m_BaseRotation, m_BaseScale, m_LightPosition, m_CameraPosition;
+		Model m_Cube;
+		Shader m_Shader;
+	};
+}

--- a/VS2017/Source/tests/TestTree1.cpp
+++ b/VS2017/Source/tests/TestTree1.cpp
@@ -38,18 +38,7 @@ namespace test {
 		m_complexModel->setRotation(45.0f, glm::vec3(0.0f, 1.0f, 0.0f));
 		m_complexModel->setScale(glm::vec3(0.5f, 0.5f, 0.5f));
 		m_complexModel->computeModelMatrix();
-		/*
-		Model* bottomCube = new Model(m_CubeObject);
-		Model* topTranslatedCube = new Model(m_CubeObject);
-		topTranslatedCube->setTranslation(glm::vec3(10.0f, 10.0f, 1.0f));
-		topTranslatedCube->setRotation(45.0f, glm::vec3(1.0f, 0.0f, 0.0f));
-		topTranslatedCube->setScale(glm::vec3(1.25f, 1.25f, 1.25f));
-		topTranslatedCube->computeModelMatrix();
-
-		m_complexModel->addModel(bottomCube);
-		m_complexModel->addModel(topTranslatedCube);
-
-		*/
+		
 		m_Tree1 = new Tree1(m_Shader, m_CubeObject);
 	}
 


### PR DESCRIPTION
Separated the terrain1 object, which previously always had rocks and grass on it, into 3 separate objects, `Terrain1`, `Rocks`, and `Grass`. This will give us more options to randomize the terrain with when it is procedurally generated.

Also created individual tests, viewable in the application test menu under `TestTerrain1`, `TestRocks`, and `TestGrass`.