### PR TITLE
Small fixes

### DIFF
--- a/VS2017/Source/Camera.cpp
+++ b/VS2017/Source/Camera.cpp
@@ -29,9 +29,6 @@ glm::mat4 Camera::GetViewMatrix() const
 
 void Camera::Update(float dt)
 {
-	/* disable mouse cursor */
-	EventManager::EnableMouseCursor();
-
 	/* mouse motion to get the variation in angle */
 	mHorizontalAngle -= EventManager::GetMouseMotionX() * mAngularSpeed * dt;
 	mVerticalAngle -= EventManager::GetMouseMotionY() * mAngularSpeed * dt;
@@ -73,5 +70,17 @@ void Camera::Update(float dt)
 	if (glfwGetKey(EventManager::GetWindow(), GLFW_KEY_A) == GLFW_PRESS)
 	{
 		mPosition -= sideVector * dt * mSpeed;
+	}
+
+	// toggle cursor on
+	if (glfwGetKey(EventManager::GetWindow(), GLFW_KEY_N) == GLFW_PRESS)
+	{
+		glfwSetInputMode(EventManager::GetWindow(), GLFW_CURSOR, GLFW_CURSOR_NORMAL);
+	}
+
+	// toggle cursor off
+	if (glfwGetKey(EventManager::GetWindow(), GLFW_KEY_M) == GLFW_PRESS)
+	{
+		glfwSetInputMode(EventManager::GetWindow(), GLFW_CURSOR, GLFW_CURSOR_DISABLED);
 	}
 }

--- a/VS2017/Source/application.cpp
+++ b/VS2017/Source/application.cpp
@@ -74,7 +74,7 @@ int main(void)
         // testMenu->RegisterTest<test::TestModel>("Model");
         // testMenu->RegisterTest<test::TestLight>("Light");
         // testMenu->RegisterTest<test::TestComplexModel>("ComplexModel");
-        testMenu->RegisterTest<test::TestTerrainGeneration>("Test Terrain Generation");
+        testMenu->RegisterTest<test::TestTerrainGeneration>("Generate Terrain");
         testMenu->RegisterTest<test::TestTerrain1>("Test Terrain1");
         testMenu->RegisterTest<test::TestBush>("Test Bush");
 		testMenu->RegisterTest<test::TestBush1>("Test Bush1");

--- a/VS2017/Source/tests/TestTerrainGeneration.cpp
+++ b/VS2017/Source/tests/TestTerrainGeneration.cpp
@@ -90,15 +90,6 @@ namespace test {
 				}
 			}
 		}
-
-		
-		// example of a cube that will line up exactly with top of given base
-		landscapeModel = new Terrain1(m_Shader, m_CubeObject);
-		translation = glm::vec3(-1 * spacing, heightMap[0][0] * spacing / 2 + objectOffset, -1 * spacing);
-		landscapeModel->setTranslation(translation);
-		landscapeModel->setScale(landscapeScale);
-		landscapeModel->computeModelMatrix();
-		m_complexModel->addComplexModel(landscapeModel);
 	}
 
 	TestTerrainGeneration::~TestTerrainGeneration()

--- a/VS2017/Source/tests/TestTerrainGeneration.cpp
+++ b/VS2017/Source/tests/TestTerrainGeneration.cpp
@@ -103,7 +103,7 @@ namespace test {
 
 	void TestTerrainGeneration::OnRender()
 	{
-		GLCall(glClearColor(0.8f, 0.3f, 0.8f, 1.0f));
+		GLCall(glClearColor(0.000f, 0.749f, 1.000f, 1.0f));
 		GLCall(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
 
 		Renderer renderer;


### PR DESCRIPTION
- Changed terrain generation sky to blue
- Enable and disable mouse cursor with `N` and `M` respectively
- Renamed `Test Terrain Generation` to `Generate Terrain`
- Removed floating example cube